### PR TITLE
Add DecompileOptions defaults to improve decompilation

### DIFF
--- a/ghidrecomp/decompile.py
+++ b/ghidrecomp/decompile.py
@@ -62,11 +62,14 @@ def setup_decompliers(program: "ghidra.program.model.listing.Program", thread_co
     """
 
     from ghidra.app.decompiler import DecompInterface
+    from ghidra.app.decompiler import DecompileOptions
 
     decompilers = {}
+    default_options = DecompileOptions()
 
     for i in range(thread_count):
         decompilers.setdefault(i, DecompInterface())
+        decompilers[i].setOptions(default_options)
         decompilers[i].openProgram(program)
 
     print(f'Setup {thread_count} decompliers')


### PR DESCRIPTION
Include default tool options when setting up the decompiler.

For example, consider this simple simple C program:
```c
#include <stdio.h>
int main() {
    float x = 1.3334;
    printf("hello %f \n", x*2.1);
}
```
Compiled as such:
```bash
gcc -o test test.c -O0
strip test
```

The decompilation before is as follows:
```c
undefined8 FUN_00101149(void)
{
  printf("hello %f \n",(double)DAT_00102014 * DAT_00102018);
  return 0;
}
```
After the change:
```c
undefined8 FUN_00101149(void)
{
  printf("hello %f \n",0x400666afd0000000);
  return 0;
}
```

I believe this is related to the options, which are set by default in the Ghidra Tool UI, are not getting set when instantiated by PyGhidra. 

I believe this particular optimization in my example is called `SIMPLIFY_DOUBLEPRECISION_OPTIONSTRING`  (see [Ghidra source]( https://github.com/NationalSecurityAgency/ghidra/blob/master/Ghidra/Features/Decompiler/src/main/java/ghidra/app/decompiler/DecompileOptions.java#L71)). I've also seen this behavior with constant pointer references when using the tool. 

I have also confirmed that `uv run pytest` still passes after this change.

Thanks!